### PR TITLE
Instantiate constant as needs a value not a factory

### DIFF
--- a/src/good/repositories/package.repository.ts
+++ b/src/good/repositories/package.repository.ts
@@ -30,5 +30,5 @@ export class PackageRepository {
 
 // Inject a raw DynamoDB client. Can easily replace with a mock for unit testing
 // or a wrapper that enhances the default behavior.
-Injector.registerConstant('DynamoDB', () => new DynamoDB.DocumentClient());
+Injector.registerConstant('DynamoDB', new DynamoDB.DocumentClient());
 Injector.register(PackageRepository, ['DynamoDB']);


### PR DESCRIPTION
Thanks for the example it's been a real help. One thing that threw me when trying out similar code was I kept getting an error when accessing a constant, I need to supply a value not a factory method to `registerConstant`. 